### PR TITLE
build(upgrade)!: update fabric references to 1.19.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 
 # Fabric Properties
-	# check these on https://fabricmc.net/develop
-	minecraft_version=1.19.2
-	yarn_mappings=1.19.2+build.28
-	loader_version=0.14.12
+# check these on https://fabricmc.net/develop
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.2
+loader_version=0.14.19
 
 # Mod Properties
-	mod_version = 0.2.1
-	maven_group = net.kris
-	archives_base_name = mpcap
-	supported_minecraft_version = 1.19.2
+mod_version = 0.2.1
+maven_group = net.kris
+archives_base_name = mpcap
+supported_minecraft_version = 1.19.4
 
 # Dependencies
-	fabric_version=0.72.0+1.19.2
+fabric_version=0.78.0+1.19.4

--- a/src/main/java/net/kris/mpcap/ClientConnectionHandler.java
+++ b/src/main/java/net/kris/mpcap/ClientConnectionHandler.java
@@ -8,7 +8,7 @@ import com.google.common.collect.Sets;
 import io.netty.channel.Channel;
 import net.kris.mpcap.mixin.ClientConnectionAccessor;
 import net.minecraft.network.ClientConnection;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 
 public class ClientConnectionHandler {
     private ClientConnection connection;

--- a/src/main/java/net/kris/mpcap/PacketMessage.java
+++ b/src/main/java/net/kris/mpcap/PacketMessage.java
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import net.kris.mpcap.util.PacketViewHelper;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.text.Text;
 
 public class PacketMessage {

--- a/src/main/java/net/kris/mpcap/PacketsViewScreen.java
+++ b/src/main/java/net/kris/mpcap/PacketsViewScreen.java
@@ -27,13 +27,13 @@ public class PacketsViewScreen extends Screen {
 
     @Override
     protected void init() {
-        this.addDrawableChild(new ButtonWidget(2, 2, 200, 20, CLEAR, button -> {
-            this.mpcap.packetHistory.clear();
-        }));
-        ButtonWidget record_toggle = new ButtonWidget(202, 2, 200, 20, this.mpcap.packetHistory.recording?DISABLE_RECORD:ENABLE_RECORD, button -> {
-            this.mpcap.packetHistory.recording = ! this.mpcap.packetHistory.recording;
-            button.setMessage(this.mpcap.packetHistory.recording?DISABLE_RECORD:ENABLE_RECORD);
-        });
+        PacketHistory history = this.mpcap.packetHistory;
+        this.addDrawableChild(new ButtonWidget.Builder(CLEAR, button -> history.clear())
+                .dimensions(2, 2, 200, 20).build());
+        ButtonWidget record_toggle = new ButtonWidget.Builder(history.recording ? DISABLE_RECORD : ENABLE_RECORD, button -> {
+            history.recording = !history.recording;
+            button.setMessage(history.recording ? DISABLE_RECORD : ENABLE_RECORD);
+        }).dimensions(202, 2, 200, 20).build();
         this.addDrawableChild(record_toggle);
     }
     

--- a/src/main/java/net/kris/mpcap/mixin/ClientConnectionMixin.java
+++ b/src/main/java/net/kris/mpcap/mixin/ClientConnectionMixin.java
@@ -12,7 +12,7 @@ import net.kris.mpcap.event.ConnectEvent;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.NetworkSide;
 import net.minecraft.network.NetworkState;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
 import net.minecraft.network.PacketCallbacks;
 
 @Mixin(ClientConnection.class)
@@ -23,11 +23,11 @@ public abstract class ClientConnectionMixin {
     public void init(NetworkSide side, CallbackInfo info) {
         ConnectEvent.invoke(this.capHandler = new ClientConnectionHandler((ClientConnection)(Object)this));
     }
-    @Inject(method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/Packet;)V",at = @At("TAIL"))
+    @Inject(method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/packet/Packet;)V",at = @At("TAIL"))
     protected void channelRead0(ChannelHandlerContext channelHandlerContext, Packet<?> packet, CallbackInfo info) {
         this.capHandler.invokeReceive(packet);
     }
-    @Inject(method = "sendInternal(Lnet/minecraft/network/Packet;Lnet/minecraft/network/PacketCallbacks;Lnet/minecraft/network/NetworkState;Lnet/minecraft/network/NetworkState;)V",at = @At(value = "TAIL"))
+    @Inject(method = "sendInternal(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;Lnet/minecraft/network/NetworkState;Lnet/minecraft/network/NetworkState;)V",at = @At(value = "TAIL"))
     private void sendInternal(Packet<?> packet, @Nullable PacketCallbacks callbacks, NetworkState packetState, NetworkState currentState, CallbackInfo info) {
         this.capHandler.invokeSend(packet);
     }

--- a/src/main/java/net/kris/mpcap/util/PacketViewHelper.java
+++ b/src/main/java/net/kris/mpcap/util/PacketViewHelper.java
@@ -19,7 +19,8 @@ import net.fabricmc.loader.api.MappingResolver;
 import net.kris.mpcap.Mpcap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.network.Packet;
+import net.minecraft.network.packet.Packet;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.hit.BlockHitResult;
@@ -27,11 +28,10 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.ChunkSectionPos;
 import net.minecraft.util.math.GlobalPos;
-import net.minecraft.util.registry.RegistryKey;
 
 public class PacketViewHelper {
     protected static HashSet<Class<?>> rawStringShowableClasses = Sets.newHashSet(BlockPos.class,ChunkPos.class,ChunkSectionPos.class,GlobalPos.class,UUID.class,NbtCompound.class,ItemStack.class,BlockHitResult.class);
-    protected static HashSet<Class<?>> stringifiableClasses = Sets.newHashSet(String.class,Identifier.class,RegistryKey.class,Date.class,BitSet.class,Optional.class);
+    protected static HashSet<Class<?>> stringifiableClasses = Sets.newHashSet(String.class,Identifier.class, RegistryKey.class,Date.class,BitSet.class,Optional.class);
     protected static MappingResolver mappingResolver = FabricLoader.getInstance().getMappingResolver();
     protected static String namespace = mappingResolver.getNamespaces().contains("named")?"named":mappingResolver.getCurrentRuntimeNamespace();
     public static String stringView(Packet<?> packet) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,8 +27,8 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.14.12",
-    "minecraft": "=1.19.2",
+    "fabricloader": ">=0.14.19",
+    "minecraft": "=1.19.4",
     "java": ">=17"
   },
   "suggests": {


### PR DESCRIPTION
Simple update to the latest version of Minecraft. Required some basic code and mixin changes but everything appears to be working as intended.

This is a breaking change, and is obviously not backwards-compatible with 1.19.2 or 1.19.3. This is because the `Packet<T>` reference was moved from `net.minecraft.network` to `net.minecraft.network.packet`.